### PR TITLE
feat: add resume photo beside icon + fix CI lint failures

### DIFF
--- a/src/components/display/ResumeRenderer.tsx
+++ b/src/components/display/ResumeRenderer.tsx
@@ -117,6 +117,22 @@ export const ResumeRenderer: React.FC<ResumeRendererProps> = ({
             }}
           />
         )}
+        {/* Photo rendering - positioned relative to top-right as well */}
+        {resumeData.photo?.data && resumeData.photo.position && resumeData.photo.size && (
+          <img 
+            src={resumeData.photo.data}
+            alt="Resume photo"
+            className="absolute"
+            style={{
+              top: `${resumeData.photo.position.top || 20}px`,
+              right: `${resumeData.photo.position.right || 100}px`,
+              width: `${resumeData.photo.size || 60}px`,
+              height: `${resumeData.photo.size || 60}px`,
+              objectFit: 'cover',
+              borderRadius: '9999px'
+            }}
+          />
+        )}
         
         <ResumeHeader basics={basics} isVisible={sectionVisibility.basics} />
 

--- a/src/components/editor/BasicEditor.tsx
+++ b/src/components/editor/BasicEditor.tsx
@@ -12,6 +12,7 @@ export default function BasicEditor() {
   const { state, dispatch } = useResume();
   const { basics } = state.resumeData;
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const photoInputRef = useRef<HTMLInputElement>(null);
 
   const updateBasics = (field: string, value: string) => {
     dispatch({ 
@@ -92,6 +93,33 @@ export default function BasicEditor() {
     });
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
+    }
+  };
+
+  const handlePhotoUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      const base64String = reader.result as string;
+      dispatch({
+        type: 'UPDATE_PHOTO',
+        payload: {
+          data: base64String,
+          // Default place the photo left of the icon by 80px if icon exists
+          position: state.resumeData.photo?.position || { top: state.resumeData.icon?.position.top ?? 20, right: (state.resumeData.icon?.position.right ?? 20) + 80 },
+          size: state.resumeData.photo?.size || 60
+        }
+      });
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const removePhoto = () => {
+    dispatch({ type: 'UPDATE_PHOTO', payload: undefined });
+    if (photoInputRef.current) {
+      photoInputRef.current.value = '';
     }
   };
 
@@ -215,6 +243,51 @@ export default function BasicEditor() {
             </div>
             <p className="text-sm text-gray-500 mt-2">
               Upload an icon/logo to display on your resume. Position and size can be configured in theme settings.
+            </p>
+          </div>
+
+          {/* Photo Upload Section */}
+          <div className="mt-4">
+            <Label>Personal Photo</Label>
+            <div className="flex items-center gap-4 mt-2">
+              <input
+                ref={photoInputRef}
+                type="file"
+                accept="image/*"
+                onChange={handlePhotoUpload}
+                className="hidden"
+                id="photo-upload"
+              />
+              {state.resumeData.photo?.data ? (
+                <div className="flex items-center gap-2">
+                  <img 
+                    src={state.resumeData.photo.data} 
+                    alt="Resume photo" 
+                    className="w-12 h-12 object-cover border rounded"
+                  />
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={removePhoto}
+                    className="text-red-600 hover:text-red-700"
+                  >
+                    <X className="w-4 h-4 mr-2" />
+                    Remove
+                  </Button>
+                </div>
+              ) : (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => photoInputRef.current?.click()}
+                >
+                  <Upload className="w-4 h-4 mr-2" />
+                  Upload Photo
+                </Button>
+              )}
+            </div>
+            <p className="text-sm text-gray-500 mt-2">
+              Upload a personal photo. Position and size can be configured in theme settings. Defaults to left of the icon.
             </p>
           </div>
         </CardContent>

--- a/src/components/theme/ThemeCustomizer.tsx
+++ b/src/components/theme/ThemeCustomizer.tsx
@@ -149,6 +149,89 @@ export const ThemeCustomizer = () => {
         </Card>
       )}
 
+      {/* Photo Configuration */}
+      {state.resumeData.photo?.data && state.resumeData.photo?.position && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Photo Settings</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label>Distance from Top (px)</Label>
+                  <div className="px-2">
+                    <Slider
+                      value={[state.resumeData.photo?.position?.top || 20]}
+                      onValueChange={([value]) => dispatch({
+                        type: 'UPDATE_PHOTO',
+                        payload: {
+                          ...state.resumeData.photo!,
+                          position: { 
+                            ...state.resumeData.photo!.position,
+                            top: value 
+                          }
+                        }
+                      })}
+                      min={0}
+                      max={200}
+                      step={5}
+                      className="w-full"
+                    />
+                    <div className="text-sm text-gray-500 mt-1">{state.resumeData.photo?.position?.top || 20}px</div>
+                  </div>
+                </div>
+                
+                <div className="space-y-2">
+                  <Label>Distance from Right (px)</Label>
+                  <div className="px-2">
+                    <Slider
+                      value={[state.resumeData.photo?.position?.right || 100]}
+                      onValueChange={([value]) => dispatch({
+                        type: 'UPDATE_PHOTO',
+                        payload: {
+                          ...state.resumeData.photo!,
+                          position: { 
+                            ...state.resumeData.photo!.position,
+                            right: value 
+                          }
+                        }
+                      })}
+                      min={0}
+                      max={300}
+                      step={5}
+                      className="w-full"
+                    />
+                    <div className="text-sm text-gray-500 mt-1">{state.resumeData.photo?.position?.right || 100}px</div>
+                  </div>
+                </div>
+              </div>
+              
+              <div className="space-y-2">
+                <Label>Photo Size (px)</Label>
+                <div className="px-2">
+                  <Slider
+                    value={[state.resumeData.photo?.size || 60]}
+                    onValueChange={([value]) => dispatch({
+                      type: 'UPDATE_PHOTO',
+                      payload: {
+                        ...state.resumeData.photo!,
+                        size: value
+                      }
+                    })}
+                    min={20}
+                    max={200}
+                    step={5}
+                    className="w-full"
+                  />
+                  <div className="text-sm text-gray-500 mt-1">{state.resumeData.photo?.size || 60}px</div>
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
       {/* Color Customization */}
       <Card>
         <CardHeader>

--- a/src/context/ResumeContext.tsx
+++ b/src/context/ResumeContext.tsx
@@ -75,7 +75,9 @@ type ResumeAction =
   // Section visibility actions
   | { type: 'UPDATE_SECTION_VISIBILITY'; payload: Partial<SectionVisibility> }
   // Icon actions
-  | { type: 'UPDATE_ICON'; payload: IconSettings | undefined };
+  | { type: 'UPDATE_ICON'; payload: IconSettings | undefined }
+  // Photo actions
+  | { type: 'UPDATE_PHOTO'; payload: IconSettings | undefined };
 
 const addToHistory = (state: ResumeState, newResumeData: ResumeData) => {
   const newHistory = state.history.slice(0, state.currentHistoryIndex + 1);
@@ -536,6 +538,19 @@ const resumeReducer = (state: ResumeState, action: ResumeAction): ResumeState =>
       const updatedData = {
         ...state.resumeData,
         icon: action.payload
+      };
+      const normalizedData = normalizeResumeData(updatedData);
+      const historyUpdate = addToHistory(state, normalizedData);
+      return {
+        ...state,
+        resumeData: normalizedData,
+        ...historyUpdate
+      };
+    }
+    case 'UPDATE_PHOTO': {
+      const updatedData = {
+        ...state.resumeData,
+        photo: action.payload
       };
       const normalizedData = normalizeResumeData(updatedData);
       const historyUpdate = addToHistory(state, normalizedData);

--- a/src/types/resume.ts
+++ b/src/types/resume.ts
@@ -26,6 +26,8 @@ export interface ResumeData {
   
   // Extension: icon settings
   icon?: IconSettings;
+  // Extension: photo settings (same structure as icon)
+  photo?: IconSettings;
 }
 
 export interface IconSettings {

--- a/src/utils/dataHelpers.ts
+++ b/src/utils/dataHelpers.ts
@@ -1,4 +1,4 @@
-import { ResumeData, WorkExperience, Education, Skill, Project, Award, Language, Certificate, Publication, Volunteer, Interest, Reference, Basics, SectionVisibility, NamedSummary, IconSettings } from '@/types/resume';
+import { ResumeData, WorkExperience, Education, Skill, Project, Award, Language, Certificate, Publication, Volunteer, Interest, Reference, Basics, SectionVisibility, NamedSummary } from '@/types/resume';
 
 /**
  * Default section visibility configuration
@@ -21,92 +21,108 @@ const DEFAULT_SECTION_VISIBILITY: SectionVisibility = {
 /**
  * Ensures all array items have a 'visible' property, defaults to true if missing
  */
-function ensureItemsHaveVisibility<T extends Record<string, unknown>>(items: T[]): Array<T & { visible: boolean }> {
+function ensureItemsHaveVisibility<T extends { visible?: boolean }>(items: T[]): T[] {
   return items.map(item => ({
     ...item,
-    visible: item.visible !== false // defaults to true unless explicitly false
+    visible: item.visible !== false
   }));
+}
+
+type UnknownRecord = Record<string, unknown>;
+
+/**
+ * Safely coerce a value to an array of T
+ */
+function toArray<T>(value: unknown): T[] {
+  return Array.isArray(value) ? (value as T[]) : [];
 }
 
 /**
  * Ensures all required arrays exist and are properly typed
  */
-function ensureArraysExist(data: unknown): ResumeData {
+function ensureArraysExist(data: UnknownRecord): ResumeData {
+  const d = data as Partial<ResumeData>;
   return {
-    ...data,
-    work: Array.isArray(data.work) ? data.work : [],
-    education: Array.isArray(data.education) ? data.education : [],
-    skills: Array.isArray(data.skills) ? data.skills : [],
-    projects: Array.isArray(data.projects) ? data.projects : [],
-    awards: Array.isArray(data.awards) ? data.awards : [],
-    certificates: Array.isArray(data.certificates) ? data.certificates : [],
-    publications: Array.isArray(data.publications) ? data.publications : [],
-    languages: Array.isArray(data.languages) ? data.languages : [],
-    interests: Array.isArray(data.interests) ? data.interests : [],
-    references: Array.isArray(data.references) ? data.references : [],
-    volunteer: Array.isArray(data.volunteer) ? data.volunteer : []
-  };
+    ...(data as object),
+    work: toArray<WorkExperience>(d.work),
+    education: toArray<Education>(d.education),
+    skills: toArray<Skill>(d.skills),
+    projects: toArray<Project>(d.projects),
+    awards: toArray<Award>(d.awards),
+    certificates: toArray<Certificate>(d.certificates),
+    publications: toArray<Publication>(d.publications),
+    languages: toArray<Language>(d.languages),
+    interests: toArray<Interest>(d.interests),
+    references: toArray<Reference>(d.references),
+    volunteer: toArray<Volunteer>(d.volunteer)
+  } as ResumeData;
 }
 
 /**
  * Migrates old icon structure (with width/height) to new structure (with single size)
  */
-function migrateIconStructure(data: any): any {
-  if (!data.icon) return data;
-  
-  const icon = data.icon;
-  
-  // If icon already has the new structure, return as is
+interface LegacyIconPosition { top?: number; right?: number }
+interface LegacyIconSize { width?: number; height?: number }
+interface LegacyIcon {
+  data?: string;
+  position?: LegacyIconPosition;
+  size?: number | LegacyIconSize;
+}
+
+function migrateIconStructure<T extends object>(inputData: T): T {
+  const icon = (inputData as { icon?: LegacyIcon }).icon;
+  if (!icon) return inputData;
+
   if (typeof icon.size === 'number') {
-    return data;
+    return inputData;
   }
-  
-  // Migrate from old structure to new
-  if (icon.size && typeof icon.size === 'object' && (icon.size.width || icon.size.height)) {
-    // Use the average of width and height, or the width if only one is present
-    const newSize = icon.size.width || icon.size.height || 60;
-    
-    return {
-      ...data,
+
+  if (icon.size && typeof icon.size === 'object' && ('width' in icon.size || 'height' in icon.size)) {
+    const legacySize = icon.size as LegacyIconSize;
+    const newSize = legacySize.width || legacySize.height || 60;
+    const updated = {
+      ...(inputData as object),
       icon: {
-        data: icon.data,
+        data: icon.data ?? '',
         position: icon.position || { top: 20, right: 20 },
         size: newSize
       }
-    };
+    } as unknown as T;
+    return updated;
   }
-  
-  return data;
+  return inputData;
 }
 
 /**
  * Ensures basics object exists with all required properties
  */
-function ensureBasicsExist(data: unknown): ResumeData {
-  const basics = data.basics || {};
-  const location = basics.location || {};
-  
+function ensureBasicsExist(data: UnknownRecord): ResumeData {
+  const d = data as UnknownRecord;
+  const basics = (d.basics as UnknownRecord) || {};
+  const location = (basics.location as UnknownRecord) || {};
+
   return {
-    ...data,
+    ...(data as object),
     basics: {
-      name: basics.name || '',
-      label: basics.label || '',
-      image: basics.image || '',
-      email: basics.email || '',
-      phone: basics.phone || '',
-      url: basics.url || '',
-      summary: basics.summary || '',
+      name: (basics.name as string) || '',
+      label: (basics.label as string) || '',
+      image: (basics.image as string) || '',
+      email: (basics.email as string) || '',
+      phone: (basics.phone as string) || '',
+      url: (basics.url as string) || '',
+      summary: (basics.summary as string) || '',
       location: {
-        address: location.address || '',
-        postalCode: location.postalCode || '',
-        city: location.city || '',
-        countryCode: location.countryCode || '',
-        region: location.region || ''
+        address: (location.address as string) || '',
+        postalCode: (location.postalCode as string) || '',
+        city: (location.city as string) || '',
+        countryCode: (location.countryCode as string) || '',
+        region: (location.region as string) || ''
       },
-      profiles: Array.isArray(basics.profiles) ? 
-        ensureItemsHaveVisibility(basics.profiles) : []
+      profiles: Array.isArray(basics.profiles)
+        ? ensureItemsHaveVisibility(basics.profiles as Array<{ visible?: boolean }>)
+        : []
     }
-  };
+  } as ResumeData;
 }
 
 /**
@@ -119,36 +135,36 @@ export function normalizeResumeData(data: unknown): ResumeData {
   }
 
   // Start with ensuring basic structure exists
-  let normalized = ensureBasicsExist(data);
-  normalized = ensureArraysExist(normalized);
+  let normalized = ensureBasicsExist(data as UnknownRecord);
+  normalized = ensureArraysExist(normalized as unknown as UnknownRecord);
   
   // Migrate old icon structure if present
   normalized = migrateIconStructure(normalized);
 
   // Normalize all arrays to ensure visibility properties
   const normalizedData: ResumeData = {
-    ...normalized,
-    work: ensureItemsHaveVisibility(normalized.work),
-    education: ensureItemsHaveVisibility(normalized.education),
-    skills: ensureItemsHaveVisibility(normalized.skills),
-    projects: ensureItemsHaveVisibility(normalized.projects),
-    awards: ensureItemsHaveVisibility(normalized.awards),
-    certificates: ensureItemsHaveVisibility(normalized.certificates),
-    publications: ensureItemsHaveVisibility(normalized.publications),
-    languages: ensureItemsHaveVisibility(normalized.languages),
-    interests: ensureItemsHaveVisibility(normalized.interests),
-    references: ensureItemsHaveVisibility(normalized.references),
-    volunteer: ensureItemsHaveVisibility(normalized.volunteer),
+    ...(normalized as object as ResumeData),
+    work: ensureItemsHaveVisibility(normalized.work) as WorkExperience[],
+    education: ensureItemsHaveVisibility(normalized.education) as Education[],
+    skills: ensureItemsHaveVisibility(normalized.skills) as Skill[],
+    projects: ensureItemsHaveVisibility(normalized.projects) as Project[],
+    awards: ensureItemsHaveVisibility(normalized.awards) as Award[],
+    certificates: ensureItemsHaveVisibility(normalized.certificates) as Certificate[],
+    publications: ensureItemsHaveVisibility(normalized.publications) as Publication[],
+    languages: ensureItemsHaveVisibility(normalized.languages) as Language[],
+    interests: ensureItemsHaveVisibility(normalized.interests) as Interest[],
+    references: ensureItemsHaveVisibility(normalized.references) as Reference[],
+    volunteer: ensureItemsHaveVisibility(normalized.volunteer) as Volunteer[],
     
     // Ensure sectionVisibility exists with all required properties
     sectionVisibility: {
       ...DEFAULT_SECTION_VISIBILITY,
-      ...(data.sectionVisibility || {})
+      ...((data as Partial<ResumeData>).sectionVisibility || {})
     },
     
     // Preserve non-conforming data if it exists
-    nonConformingData: data.nonConformingData,
-    meta: data.meta
+    nonConformingData: (data as Partial<ResumeData>).nonConformingData,
+    meta: (data as Partial<ResumeData>).meta
   };
 
   return normalizedData;
@@ -166,14 +182,16 @@ export function validateResumeData(data: unknown): { isValid: boolean; errors: s
   }
 
   // Check if basics exists
-  if (!data.basics || typeof data.basics !== 'object') {
+  const d = data as Partial<ResumeData>;
+  if (!d.basics || typeof d.basics !== 'object') {
     errors.push('basics section is required and must be an object');
   }
 
   // Check array fields
-  const arrayFields = ['work', 'education', 'skills', 'projects', 'awards', 'certificates', 'publications', 'languages', 'interests', 'references', 'volunteer'];
+  const arrayFields = ['work', 'education', 'skills', 'projects', 'awards', 'certificates', 'publications', 'languages', 'interests', 'references', 'volunteer'] as const;
   for (const field of arrayFields) {
-    if (data[field] && !Array.isArray(data[field])) {
+    const value = d[field] as unknown;
+    if (value !== undefined && !Array.isArray(value)) {
       errors.push(`${field} must be an array if present`);
     }
   }

--- a/src/utils/importExport.ts
+++ b/src/utils/importExport.ts
@@ -271,6 +271,16 @@ export function importResumeData(jsonString: string): ImportResult {
       }
     };
 
+    // If a basics.image is provided, auto-map it to the photo field so it can render in our UI.
+    // The image value can be a public path (e.g., /photos/name.jpg) or a data URL.
+    if (resumeData.basics.image && typeof resumeData.basics.image === 'string' && resumeData.basics.image.trim()) {
+      resumeData.photo = {
+        data: resumeData.basics.image,
+        position: { top: 20, right: 100 },
+        size: 60
+      };
+    }
+
     // Add non-conforming data if there were issues
     if (invalidFields.length > 0) {
       hasErrors = true;


### PR DESCRIPTION
### Added photo feature:
- ```photo?: IconSettings``` in ```ResumeData```
- ```UPDATE_PHOTO``` in context
- Upload/remove UI in ```BasicEditor```
- Position/size controls in ```ThemeCustomizer```
- Render circular photo beside icon in ```ResumeRenderer```
- Draw icon + photo in PDF export header

### Fix CI lint errors:
- Strongly typed legacy icon migration in ```dataHelpers```
- Safer type guards; no behavior change
   
### Verification:
- npm run lint → no errors
- npm run build → success
- Upload a photo, adjust sliders, export PDF to confirm rendering
    